### PR TITLE
Add 'ts-postgres' to benchmarks

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const queries = [
       'pg-promise-native',
       'pg',
       'pg-native',
-      'slonik'
+      'slonik',
+      'ts-postgres'
     ]
     , warmup = 3
     , iterations = 10000

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,11 @@
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
       "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
     },
+    "generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
+    },
     "get-stack-trace": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/get-stack-trace/-/get-stack-trace-2.0.3.tgz",
@@ -708,6 +713,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "ts-postgres": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-postgres/-/ts-postgres-2.0.1.tgz",
+      "integrity": "sha512-tN8bDZpy82yP0xW9BGRT4cYgRlTy+dKfMeCaf8fcQ6Ddd7RSIczjr8Bsp/vMzs0AjI8FA5RXNjFUa3+UDUDzCA=="
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "generic-pool": "^3.9.0",
     "pg": "8.5.1",
     "pg-native": "3.0.0",
     "pg-promise": "10.9.2",
     "postgres": "1.0.2",
-    "slonik": "23.5.5"
+    "slonik": "23.5.5",
+    "ts-postgres": "2.0.1"
   }
 }

--- a/ts-postgres/index.js
+++ b/ts-postgres/index.js
@@ -1,0 +1,38 @@
+const { connect } = require('ts-postgres')
+const { createPool } = require('generic-pool');
+
+const pool = createPool(
+    {
+      create: connect,
+      destroy: client => client.end()
+    },
+    { max: 4 },
+);
+
+const query = (text, values) => pool.use(async client => client.query(text, values))
+
+module.exports = {
+  queries: {
+    select: () => query('select 1 as x'),
+    select_arg: () => query('select $1 as x', [1]),
+    select_args: () => query(`select
+      $1::int as int,
+      $2 as string,
+      $3::timestamp with time zone as timestamp,
+      $4 as null,
+      $5::bool as boolean,
+      $6::bytea as bytea,
+      $7::jsonb as json
+    `, [
+      1337,
+      'wat',
+      new Date().toISOString(),
+      null,
+      false,
+      Buffer.from('awesome'),
+      [{ some: 'json' }, { array: 'object' }]
+    ]),
+    select_where: () => query('select * from pg_catalog.pg_type where typname = $1', ['bool'])
+  },
+  end: () => Promise.all([pool.drain(), pool.clear()])
+}


### PR DESCRIPTION
This adds [ts-postgres](https://www.npmjs.com/package/ts-postgres) to the benchmark suite.

Local results:
client     |         select |     select_arg |    select_args |   select_where
:--------- | -------------: | -------------: | -------------: | -------------:
postgres   |  0.061s (7.9x) |  0.065s (9.4x) |  0.126s (5.5x) |  0.106s (7.5x)
pg-promise |  0.190s (2.5x) |  0.197s (3.1x) |  0.279s (2.5x) |  0.296s (2.7x)
pg-promise-native |  0.181s (2.6x) |  0.200s (3.1x) |  0.277s (2.5x) |  0.305s (2.6x)
pg         |  0.161s (3.0x) |  0.282s (2.2x) |  0.346s (2.0x) |  0.386s (2.1x)
pg-native  |  0.155s (3.1x) |  0.160s (3.8x) |  0.243s (2.8x) |  0.278s (2.9x)
slonik     |  0.480s (1.0x) |  0.609s (1.0x) |  0.691s (1.0x) |  0.798s (1.0x)
ts-postgres |  0.283s (1.7x) |  0.434s (1.4x) |  0.517s (1.3x) |  0.558s (1.4x)

This is based on https://github.com/porsager/postgres-benchmarks/pull/10 which updates the suite to the latest drivers.